### PR TITLE
e.getStatusCode() was throwing an error

### DIFF
--- a/nest.devicetype.groovy
+++ b/nest.devicetype.groovy
@@ -275,9 +275,7 @@ def doRequest(uri, args, type, success) {
             httpGet(params, success)
         }
     } catch (Throwable e) {
-        if(e.getStatusCode() == 401) {
-            login()
-        }
+        login()
     }
 }
 


### PR DESCRIPTION
Expired certs were never getting to login() as it was throwing an error.  I think it's due to sandbox restrictions.
