### PR TITLE
Fixing Presence to work with iOS app update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,5 @@
 # Nest Device Type
-http://build.smartthings.com/projects/smartnest/
+Please use the updated SmartApp found here:
 
-Now SmartThings can talk to your Nest thermostat.
+https://github.com/tonesto7/nest-manager
 
-Note: this is technically against the Nest TOS. So use at your own risk.
-
-## Installation
-
-1. Create a new device type (https://graph.api.smartthings.com/ide/devices)
-    * Name: Nest
-    * Author: dianoga7@3dgo.net
-    * Namespace: smartthings-users
-    * Capabilities:
-        * Polling
-        * Relative Humidity Measurement
-        * Thermostat
-        * Temperature Measurement
-		* Presence Sensor
-		* Sensor
-    * Custom Attributes:
-        * temperatureUnit
-    * Custom Commands:
-        * away
-        * present
-        * setPresence
-        * heatingSetpointUp
-        * heatingSetpointDown
-        * coolingSetpointUp
-        * coolingSetpointDown
-        * setFahrenheit
-        * setCelsius
-
-1. Publish the device type (next to Save button) > For Me
-
-1. If you want to switch from slider controls to buttons, comment out the slider details line and uncomment the button details line.
-
-1. Create a new device (https://graph.api.smartthings.com/device/list)
-    * Name: Your Choice
-    * Device Network Id: Your Choice
-    * Type: Nest (should be the last option)
-    * Location: Choose the correct location
-    * Hub/Group: Leave blank
-
-1. Update device preferences
-    * Click on the new device to see the details.
-    * Click the edit button next to Preferences
-    * Fill in your information.
-    * To find your serial number, login to http://home.nest.com. Click on the thermostat you want to control. Under settings, go to Technical Info. Your serial number is the second item.
-
-1. That's it, you're done.

--- a/nest.devicetype.groovy
+++ b/nest.devicetype.groovy
@@ -3,7 +3,7 @@
  *
  *  Author: dianoga7@3dgo.net, desertblade@gmail.com
  *  Original Code: https://github.com/smartthings-users/device-type.nest
- *  Modified Code: 
+ *  Modified Code: https://github.com/desertblade/device-type.nest
  *
  * INSTALLATION
  * =========================================

--- a/nest.devicetype.groovy
+++ b/nest.devicetype.groovy
@@ -1,9 +1,8 @@
 /**
  *  Nest Direct
  *
- *  Author: dianoga7@3dgo.net, desertblade@gmail.com
+ *  Author: dianoga7@3dgo.net
  *  Original Code: https://github.com/smartthings-users/device-type.nest
- *  Modified Code: https://github.com/desertblade/device-type.nest
  *
  * INSTALLATION
  * =========================================

--- a/nest.devicetype.groovy
+++ b/nest.devicetype.groovy
@@ -2,7 +2,7 @@
  *  Nest Direct
  *
  *  Author: dianoga7@3dgo.net
- *  Original Code: https://github.com/smartthings-users/device-type.nest
+ *  Code: https://github.com/smartthings-users/device-type.nest
  *
  * INSTALLATION
  * =========================================

--- a/nest.devicetype.groovy
+++ b/nest.devicetype.groovy
@@ -1,8 +1,9 @@
 /**
  *  Nest Direct
  *
- *  Author: dianoga7@3dgo.net
- *  Code: https://github.com/smartthings-users/device-type.nest
+ *  Author: dianoga7@3dgo.net, desertblade@gmail.com
+ *  Original Code: https://github.com/smartthings-users/device-type.nest
+ *  Modified Code: 
  *
  * INSTALLATION
  * =========================================
@@ -21,7 +22,7 @@
  *     Custom Commands:
  *         away
  *         present
- *         setPresence
+ *         setNestPresence
  *         heatingSetpointUp
  *         heatingSetpointDown
  *         coolingSetpointUp
@@ -83,7 +84,7 @@ metadata {
 
 		command "away"
 		command "present"
-		command "setPresence"
+		command "setNestPresence"
 		command "heatingSetpointUp"
 		command "heatingSetpointDown"
 		command "coolingSetpointUp"
@@ -153,7 +154,7 @@ metadata {
 			state "default", label:'${currentValue}%', unit:"Humidity"
 		}
 
-		standardTile("presence", "device.presence", inactiveLabel: false, decoration: "flat") {
+		standardTile("nestPresence", "device.nestPresence", inactiveLabel: false, decoration: "flat") {
 			state "present", label:'${name}', action:"away", icon: "st.Home.home2"
 			state "not present", label:'away', action:"present", icon: "st.Transportation.transportation5"
 		}
@@ -197,8 +198,8 @@ metadata {
 		// To expose buttons, comment out the first detials line below and uncomment the second details line below.
 		// To expose sliders, uncomment the first details line below and comment out the second details line below.
 
-		details(["temperature", "thermostatOperatingState", "humidity", "thermostatMode", "thermostatFanMode", "presence", "heatingSetpoint", "heatSliderControl", "coolingSetpoint", "coolSliderControl", "temperatureUnit", "refresh"])
-		// details(["temperature", "thermostatOperatingState", "humidity", "thermostatMode", "thermostatFanMode", "presence", "heatingSetpointDown", "heatingSetpoint", "heatingSetpointUp", "coolingSetpointDown", "coolingSetpoint", "coolingSetpointUp", "temperatureUnit", "refresh"])
+		//details(["temperature", "thermostatOperatingState", "humidity", "thermostatMode", "thermostatFanMode", "nestPresence", "heatingSetpoint", "heatSliderControl", "coolingSetpoint", "coolSliderControl", "temperatureUnit", "refresh"])
+		 details(["temperature", "thermostatOperatingState", "humidity", "thermostatMode", "thermostatFanMode", "nestPresence", "heatingSetpointDown", "heatingSetpoint", "heatingSetpointUp", "coolingSetpointDown", "coolingSetpoint", "coolingSetpointUp", "temperatureUnit", "refresh"])
 
 		// ============================================================
 
@@ -400,18 +401,18 @@ def setThermostatFanMode(mode) {
 }
 
 def away() {
-	setPresence('away')
-	sendEvent(name: 'presence', value: 'not present')
+	setNestPresence('away')
+	sendEvent(name: 'nestPresence', value: 'not present')
 }
 
 def present() {
-	setPresence('present')
-	sendEvent(name: 'presence', value: 'present')
+	setNestPresence('present')
+	sendEvent(name: 'nestPresence', value: 'present')
 }
 
-def setPresence(status) {
+def setNestPresence(status) {
 	log.debug "Status: $status"
-	api('presence', ['away': status == 'away', 'away_timestamp': new Date().getTime(), 'away_setter': 0]) {
+	api('nestPresence', ['away': status == 'away', 'away_timestamp': new Date().getTime(), 'away_setter': 0]) {
 		poll()
 	}
 }
@@ -480,15 +481,15 @@ def poll() {
 				break;
 			}
 
-		switch (device.latestValue('presence')) {
+		switch (device.latestValue('nestPresence')) {
 			case "present":
 				if (data.structure.away == 'away') {
-					sendEvent(name: 'presence', value: 'not present')
+					sendEvent(name: 'nestPresence', value: 'not present')
 				}
 				break;
 			case "not present":
 				if (data.structure.away == 'present') {
-					sendEvent(name: 'presence', value: 'present')
+					sendEvent(name: 'nestPresence', value: 'present')
 				}
 				break;
 		}
@@ -517,7 +518,7 @@ def api(method, args = [], success = {}) {
 		'fan_mode': [uri: "/v2/put/device.${settings.serial}", type: 'post'],
 		'thermostat_mode': [uri: "/v2/put/shared.${settings.serial}", type: 'post'],
 		'temperature': [uri: "/v2/put/shared.${settings.serial}", type: 'post'],
-		'presence': [uri: "/v2/put/structure.${data.structureId}", type: 'post']
+		'nestPresence': [uri: "/v2/put/structure.${data.structureId}", type: 'post']
 	]
 
 	def request = methods.getAt(method)

--- a/nest.devicetype.groovy
+++ b/nest.devicetype.groovy
@@ -78,7 +78,6 @@ metadata {
 		capability "Relative Humidity Measurement"
 		capability "Thermostat"
 		capability "Temperature Measurement"
-		capability "Presence Sensor"
 		capability "Sensor"
 
 		command "away"

--- a/nest.devicetype.groovy
+++ b/nest.devicetype.groovy
@@ -90,12 +90,8 @@ metadata {
 		command "coolingSetpointDown"
 		command "setFahrenheit"
 		command "setCelsius"
-		command "setHumiditySetpoint"
-		command "humiditySetpointUp"
-		command "humiditySetpointDown"
 
 		attribute "temperatureUnit", "string"
-		attribute "humiditySetpoint", "number"
 	}
 
 	simulator {
@@ -156,10 +152,6 @@ metadata {
 		valueTile("humidity", "device.humidity", inactiveLabel: false) {
 			state "default", label:'${currentValue}%', unit:"Humidity"
 		}
-		
-		valueTile("humiditySetpoint", "humiditySetpoint", inactiveLabel: false) {
-			state "default", label:'${currentValue}%', unit:"Humidity", backgroundColor:"#308014"
-		}
 
 		standardTile("nestPresence", "device.nestPresence", inactiveLabel: false, decoration: "flat") {
 			state "present", label:'${name}', action:"away", icon: "st.Home.home2"
@@ -182,10 +174,6 @@ metadata {
 			state "setCoolingSetpoint", label:'Set temperature to', action:"thermostat.setCoolingSetpoint"
 		}
 
-		controlTile("humiditySliderControl", "humiditySetpoint", "slider", height: 1, width: 2, inactiveLabel: false) {
-			state "setHumiditySetpoint", label:'Set humidity to', action:"thermostat.setHumiditySetpoint"
-		}
-
 		standardTile("heatingSetpointUp", "device.heatingSetpoint", canChangeIcon: false, inactiveLabel: false, decoration: "flat") {
 			state "heatingSetpointUp", label:'  ', action:"heatingSetpointUp", icon:"st.thermostat.thermostat-up", backgroundColor:"#bc2323"
 		}
@@ -201,14 +189,6 @@ metadata {
 		standardTile("coolingSetpointDown", "device.coolingSetpoint", canChangeIcon: false, inactiveLabel: false, decoration: "flat") {
 			state "coolingSetpointDown", label:'  ', action:"coolingSetpointDown", icon:"st.thermostat.thermostat-down", backgroundColor:"#1e9cbb"
 		}
-		
-		standardTile("humiditySetpointUp", "humiditySetpoint", canChangeIcon: false, inactiveLabel: false, decoration: "flat") {
-			state "humiditySetpointUp", label:'  ', action:"humiditySetpointUp", icon:"st.thermostat.thermostat-up", backgroundColor:"#1e9cbb"
-		}
-
-		standardTile("humiditySetpointDown", "device.humiditySetpoint", canChangeIcon: false, inactiveLabel: false, decoration: "flat") {
-			state "humiditySetpointDown", label:'  ', action:"humiditySetpointDown", icon:"st.thermostat.thermostat-down", backgroundColor:"#1e9cbb"
-		}
 
 		main(["temperature", "thermostatOperatingState", "humidity"])
 
@@ -217,20 +197,13 @@ metadata {
 		// To expose buttons, comment out the first detials line below and uncomment the second details line below.
 		// To expose sliders, uncomment the first details line below and comment out the second details line below.
 
-		//details(["temperature", "thermostatOperatingState", "humidity", "thermostatMode", "thermostatFanMode", "nestPresence", "heatingSetpoint", "heatSliderControl", "coolingSetpoint", "coolSliderControl", "humiditySetpoint", "humiditySliderControl", "temperatureUnit", "refresh"])
-		details(["temperature", "thermostatOperatingState", "humidity", "thermostatMode", "thermostatFanMode", "nestPpresence", "heatingSetpointDown", "heatingSetpoint", "heatingSetpointUp", "coolingSetpointDown", "coolingSetpoint", "coolingSetpointUp", "humiditySetpointDown", "humiditySetpoint", "humiditySetpointUp", "temperatureUnit","refresh"])
+		//details(["temperature", "thermostatOperatingState", "humidity", "thermostatMode", "thermostatFanMode", "nestPresence", "heatingSetpoint", "heatSliderControl", "coolingSetpoint", "coolSliderControl", "temperatureUnit", "refresh"])
+		 details(["temperature", "thermostatOperatingState", "humidity", "thermostatMode", "thermostatFanMode", "nestPresence", "heatingSetpointDown", "heatingSetpoint", "heatingSetpointUp", "coolingSetpointDown", "coolingSetpoint", "coolingSetpointUp", "temperatureUnit", "refresh"])
 
 		// ============================================================
 
 	}
 
-}
-
-// update preferences
-def updated() {
-	log.debug "Updated"
-	// reset the authentication
-	data.auth = null
 }
 
 // parse events into attributes
@@ -242,7 +215,7 @@ def parse(String description) {
 def setHeatingSetpoint(temp) {
 	def latestThermostatMode = device.latestState('thermostatMode')
 	def temperatureUnit = device.latestValue('temperatureUnit')
-  
+
 	switch (temperatureUnit) {
 		case "celsius":
 			if (temp) {
@@ -301,7 +274,7 @@ def coolingSetpointDown(){
 def setCoolingSetpoint(temp) {
 	def latestThermostatMode = device.latestState('thermostatMode')
 	def temperatureUnit = device.latestValue('temperatureUnit')
-	
+
 	switch (temperatureUnit) {
 		case "celsius":
 			if (temp) {
@@ -368,27 +341,6 @@ def setCelsius() {
 	def temperatureUnit = "celsius"
 	log.debug "Setting temperatureUnit to: ${temperatureUnit}"
 	sendEvent(name: "temperatureUnit",   value: temperatureUnit)
-	poll()
-}
-
-def humiditySetpointUp(){
-	int newSetpoint = device.latestValue("humiditySetpoint") + 1
-	log.debug "Setting humidity set point up to: ${newSetpoint}"
-	setHumiditySetpoint(newSetpoint)
-}
-
-def humiditySetpointDown(){
-	int newSetpoint = device.latestValue('humiditySetpoint') - 1
-	log.debug "Setting humidity set point down to: ${newSetpoint}"
-	setHumiditySetpoint(newSetpoint)
-}
-
-def setHumiditySetpoint(humiditySP) {
-	if (humiditySP > 0) {
-		api('humidity', ['target_humidity': humiditySP]) {
-			sendEvent(name: 'humiditySetpoint', value: humiditySetpoint, unit: Humidity)
-		}
-	}
 	poll()
 }
 
@@ -475,19 +427,17 @@ def poll() {
 		data.device.fan_mode = data.device.fan_mode == 'duty-cycle'? 'circulate' : data.device.fan_mode
 		data.structure.away = data.structure.away ? 'away' : 'present'
 
-		log.debug("data.shared: " + data.shared)
-		
+		log.debug(data.shared)
+
 		def humidity = data.device.current_humidity
-		def humiditySetpoint = Math.round(data.device.target_humidity)
 		def temperatureType = data.shared.target_temperature_type
 		def fanMode = data.device.fan_mode
-		def heatingSetpoint = 0
-		def coolingSetpoint = 0
+		def heatingSetpoint = '--'
+		def coolingSetpoint = '--'
 
 		temperatureType = temperatureType == 'range' ? 'auto' : temperatureType
 
 		sendEvent(name: 'humidity', value: humidity)
-		sendEvent(name: 'humiditySetpoint', value: humiditySetpoint, unit: Humidity)
 		sendEvent(name: 'thermostatFanMode', value: fanMode)
 		sendEvent(name: 'thermostatMode', value: temperatureType)
 
@@ -497,7 +447,7 @@ def poll() {
 			case "celsius":
 				def temperature = Math.round(data.shared.current_temperature)
 				def targetTemperature = Math.round(data.shared.target_temperature)
-				
+
 				if (temperatureType == "cool") {
 					coolingSetpoint = targetTemperature
 				} else if (temperatureType == "heat") {
@@ -513,8 +463,8 @@ def poll() {
 				break;
 			default:
 				def temperature = Math.round(cToF(data.shared.current_temperature))
-				def targetTemperature = Math.round(cToF(data.shared.target_temperature))				
-				
+				def targetTemperature = Math.round(cToF(data.shared.target_temperature))
+
 				if (temperatureType == "cool") {
 					coolingSetpoint = targetTemperature
 				} else if (temperatureType == "heat") {
@@ -530,15 +480,15 @@ def poll() {
 				break;
 			}
 
-		switch (device.latestValue('presence')) {
+		switch (device.latestValue('nestPresence')) {
 			case "present":
 				if (data.structure.away == 'away') {
-					sendEvent(name: 'presence', value: 'not present')
+					sendEvent(name: 'nestPresence', value: 'not present')
 				}
 				break;
 			case "not present":
 				if (data.structure.away == 'present') {
-					sendEvent(name: 'presence', value: 'present')
+					sendEvent(name: 'nestPresence', value: 'present')
 				}
 				break;
 		}
@@ -567,8 +517,7 @@ def api(method, args = [], success = {}) {
 		'fan_mode': [uri: "/v2/put/device.${settings.serial}", type: 'post'],
 		'thermostat_mode': [uri: "/v2/put/shared.${settings.serial}", type: 'post'],
 		'temperature': [uri: "/v2/put/shared.${settings.serial}", type: 'post'],
-		'nestPresence': [uri: "/v2/put/structure.${data.structureId}", type: 'post'],
-		'humidity': [uri: "/v2/put/device.${settings.serial}", type: 'post'],
+		'nestPresence': [uri: "/v2/put/structure.${data.structureId}", type: 'post']
 	]
 
 	def request = methods.getAt(method)

--- a/nest.devicetype.groovy
+++ b/nest.devicetype.groovy
@@ -90,8 +90,12 @@ metadata {
 		command "coolingSetpointDown"
 		command "setFahrenheit"
 		command "setCelsius"
+		command "setHumiditySetpoint"
+		command "humiditySetpointUp"
+		command "humiditySetpointDown"
 
 		attribute "temperatureUnit", "string"
+		attribute "humiditySetpoint", "number"
 	}
 
 	simulator {
@@ -152,6 +156,10 @@ metadata {
 		valueTile("humidity", "device.humidity", inactiveLabel: false) {
 			state "default", label:'${currentValue}%', unit:"Humidity"
 		}
+		
+		valueTile("humiditySetpoint", "humiditySetpoint", inactiveLabel: false) {
+			state "default", label:'${currentValue}%', unit:"Humidity", backgroundColor:"#308014"
+		}
 
 		standardTile("nestPresence", "device.nestPresence", inactiveLabel: false, decoration: "flat") {
 			state "present", label:'${name}', action:"away", icon: "st.Home.home2"
@@ -174,6 +182,10 @@ metadata {
 			state "setCoolingSetpoint", label:'Set temperature to', action:"thermostat.setCoolingSetpoint"
 		}
 
+		controlTile("humiditySliderControl", "humiditySetpoint", "slider", height: 1, width: 2, inactiveLabel: false) {
+			state "setHumiditySetpoint", label:'Set humidity to', action:"thermostat.setHumiditySetpoint"
+		}
+
 		standardTile("heatingSetpointUp", "device.heatingSetpoint", canChangeIcon: false, inactiveLabel: false, decoration: "flat") {
 			state "heatingSetpointUp", label:'  ', action:"heatingSetpointUp", icon:"st.thermostat.thermostat-up", backgroundColor:"#bc2323"
 		}
@@ -189,6 +201,14 @@ metadata {
 		standardTile("coolingSetpointDown", "device.coolingSetpoint", canChangeIcon: false, inactiveLabel: false, decoration: "flat") {
 			state "coolingSetpointDown", label:'  ', action:"coolingSetpointDown", icon:"st.thermostat.thermostat-down", backgroundColor:"#1e9cbb"
 		}
+		
+		standardTile("humiditySetpointUp", "humiditySetpoint", canChangeIcon: false, inactiveLabel: false, decoration: "flat") {
+			state "humiditySetpointUp", label:'  ', action:"humiditySetpointUp", icon:"st.thermostat.thermostat-up", backgroundColor:"#1e9cbb"
+		}
+
+		standardTile("humiditySetpointDown", "device.humiditySetpoint", canChangeIcon: false, inactiveLabel: false, decoration: "flat") {
+			state "humiditySetpointDown", label:'  ', action:"humiditySetpointDown", icon:"st.thermostat.thermostat-down", backgroundColor:"#1e9cbb"
+		}
 
 		main(["temperature", "thermostatOperatingState", "humidity"])
 
@@ -197,13 +217,20 @@ metadata {
 		// To expose buttons, comment out the first detials line below and uncomment the second details line below.
 		// To expose sliders, uncomment the first details line below and comment out the second details line below.
 
-		//details(["temperature", "thermostatOperatingState", "humidity", "thermostatMode", "thermostatFanMode", "nestPresence", "heatingSetpoint", "heatSliderControl", "coolingSetpoint", "coolSliderControl", "temperatureUnit", "refresh"])
-		 details(["temperature", "thermostatOperatingState", "humidity", "thermostatMode", "thermostatFanMode", "nestPresence", "heatingSetpointDown", "heatingSetpoint", "heatingSetpointUp", "coolingSetpointDown", "coolingSetpoint", "coolingSetpointUp", "temperatureUnit", "refresh"])
+		//details(["temperature", "thermostatOperatingState", "humidity", "thermostatMode", "thermostatFanMode", "nestPresence", "heatingSetpoint", "heatSliderControl", "coolingSetpoint", "coolSliderControl", "humiditySetpoint", "humiditySliderControl", "temperatureUnit", "refresh"])
+		details(["temperature", "thermostatOperatingState", "humidity", "thermostatMode", "thermostatFanMode", "nestPpresence", "heatingSetpointDown", "heatingSetpoint", "heatingSetpointUp", "coolingSetpointDown", "coolingSetpoint", "coolingSetpointUp", "humiditySetpointDown", "humiditySetpoint", "humiditySetpointUp", "temperatureUnit","refresh"])
 
 		// ============================================================
 
 	}
 
+}
+
+// update preferences
+def updated() {
+	log.debug "Updated"
+	// reset the authentication
+	data.auth = null
 }
 
 // parse events into attributes
@@ -215,7 +242,7 @@ def parse(String description) {
 def setHeatingSetpoint(temp) {
 	def latestThermostatMode = device.latestState('thermostatMode')
 	def temperatureUnit = device.latestValue('temperatureUnit')
-
+  
 	switch (temperatureUnit) {
 		case "celsius":
 			if (temp) {
@@ -274,7 +301,7 @@ def coolingSetpointDown(){
 def setCoolingSetpoint(temp) {
 	def latestThermostatMode = device.latestState('thermostatMode')
 	def temperatureUnit = device.latestValue('temperatureUnit')
-
+	
 	switch (temperatureUnit) {
 		case "celsius":
 			if (temp) {
@@ -341,6 +368,27 @@ def setCelsius() {
 	def temperatureUnit = "celsius"
 	log.debug "Setting temperatureUnit to: ${temperatureUnit}"
 	sendEvent(name: "temperatureUnit",   value: temperatureUnit)
+	poll()
+}
+
+def humiditySetpointUp(){
+	int newSetpoint = device.latestValue("humiditySetpoint") + 1
+	log.debug "Setting humidity set point up to: ${newSetpoint}"
+	setHumiditySetpoint(newSetpoint)
+}
+
+def humiditySetpointDown(){
+	int newSetpoint = device.latestValue('humiditySetpoint') - 1
+	log.debug "Setting humidity set point down to: ${newSetpoint}"
+	setHumiditySetpoint(newSetpoint)
+}
+
+def setHumiditySetpoint(humiditySP) {
+	if (humiditySP > 0) {
+		api('humidity', ['target_humidity': humiditySP]) {
+			sendEvent(name: 'humiditySetpoint', value: humiditySetpoint, unit: Humidity)
+		}
+	}
 	poll()
 }
 
@@ -427,17 +475,19 @@ def poll() {
 		data.device.fan_mode = data.device.fan_mode == 'duty-cycle'? 'circulate' : data.device.fan_mode
 		data.structure.away = data.structure.away ? 'away' : 'present'
 
-		log.debug(data.shared)
-
+		log.debug("data.shared: " + data.shared)
+		
 		def humidity = data.device.current_humidity
+		def humiditySetpoint = Math.round(data.device.target_humidity)
 		def temperatureType = data.shared.target_temperature_type
 		def fanMode = data.device.fan_mode
-		def heatingSetpoint = '--'
-		def coolingSetpoint = '--'
+		def heatingSetpoint = 0
+		def coolingSetpoint = 0
 
 		temperatureType = temperatureType == 'range' ? 'auto' : temperatureType
 
 		sendEvent(name: 'humidity', value: humidity)
+		sendEvent(name: 'humiditySetpoint', value: humiditySetpoint, unit: Humidity)
 		sendEvent(name: 'thermostatFanMode', value: fanMode)
 		sendEvent(name: 'thermostatMode', value: temperatureType)
 
@@ -447,7 +497,7 @@ def poll() {
 			case "celsius":
 				def temperature = Math.round(data.shared.current_temperature)
 				def targetTemperature = Math.round(data.shared.target_temperature)
-
+				
 				if (temperatureType == "cool") {
 					coolingSetpoint = targetTemperature
 				} else if (temperatureType == "heat") {
@@ -463,8 +513,8 @@ def poll() {
 				break;
 			default:
 				def temperature = Math.round(cToF(data.shared.current_temperature))
-				def targetTemperature = Math.round(cToF(data.shared.target_temperature))
-
+				def targetTemperature = Math.round(cToF(data.shared.target_temperature))				
+				
 				if (temperatureType == "cool") {
 					coolingSetpoint = targetTemperature
 				} else if (temperatureType == "heat") {
@@ -480,15 +530,15 @@ def poll() {
 				break;
 			}
 
-		switch (device.latestValue('nestPresence')) {
+		switch (device.latestValue('presence')) {
 			case "present":
 				if (data.structure.away == 'away') {
-					sendEvent(name: 'nestPresence', value: 'not present')
+					sendEvent(name: 'presence', value: 'not present')
 				}
 				break;
 			case "not present":
 				if (data.structure.away == 'present') {
-					sendEvent(name: 'nestPresence', value: 'present')
+					sendEvent(name: 'presence', value: 'present')
 				}
 				break;
 		}
@@ -517,7 +567,8 @@ def api(method, args = [], success = {}) {
 		'fan_mode': [uri: "/v2/put/device.${settings.serial}", type: 'post'],
 		'thermostat_mode': [uri: "/v2/put/shared.${settings.serial}", type: 'post'],
 		'temperature': [uri: "/v2/put/shared.${settings.serial}", type: 'post'],
-		'nestPresence': [uri: "/v2/put/structure.${data.structureId}", type: 'post']
+		'nestPresence': [uri: "/v2/put/structure.${data.structureId}", type: 'post'],
+		'humidity': [uri: "/v2/put/device.${settings.serial}", type: 'post'],
 	]
 
 	def request = methods.getAt(method)


### PR DESCRIPTION
Issue reported in Smartthings community about Nest causing Smartthings app to crash.  Changed references of "presence" to "nestPresence".  I believe "presence" is a singular use tile with the latest updates, and when used in Nest device was not using it properly which caused the crash.

Community Threads (with confirmation of fix):
https://community.smartthings.com/t/another-update-another-issue/31031/30
https://community.smartthings.com/t/another-update-another-issue/31031/28
